### PR TITLE
feature/GEINFRA-256: Lookup psycopg error codes and change http status code if needed

### DIFF
--- a/ge_core_shared/exception_handlers.py
+++ b/ge_core_shared/exception_handlers.py
@@ -1,12 +1,22 @@
 import logging
 import json
 
+from psycopg2 import errorcodes
+
 from project.app import DB as db
 
 logger = logging.getLogger(__name__)
 
+PG_ERROR_STATUS_CODE_MAP = {
+    "UNIQUE_VIOLATION": 409
+}
 
 def db_exceptions(exception):
     logger.error(exception)
     db.session.rollback()
-    return json.dumps({"error": exception._message().replace("\n", " ")}), 500
+    error_type = errorcodes.lookup(exception.orig.pgcode)
+    return json.dumps(
+        {
+            "error": exception.orig.pgerror
+        }
+    ), PG_ERROR_STATUS_CODE_MAP.get(error_type, 500)

--- a/ge_core_shared/exception_handlers.py
+++ b/ge_core_shared/exception_handlers.py
@@ -17,6 +17,6 @@ def db_exceptions(exception):
     error_type = errorcodes.lookup(exception.orig.pgcode)
     return json.dumps(
         {
-            "error": exception.orig.pgerror
+            "error": exception.orig.pgerror.replace("\n", " ")
         }
     ), PG_ERROR_STATUS_CODE_MAP.get(error_type, 500)

--- a/ge_core_shared/exception_handlers.py
+++ b/ge_core_shared/exception_handlers.py
@@ -17,6 +17,6 @@ def db_exceptions(exception):
     error_type = errorcodes.lookup(exception.orig.pgcode)
     return json.dumps(
         {
-            "error": exception.orig.pgerror.replace("\n", " ")
+            "error": exception.orig.pgerror.strip().replace("\n", " ")
         }
     ), PG_ERROR_STATUS_CODE_MAP.get(error_type, 500)

--- a/ge_core_shared/exception_handlers.py
+++ b/ge_core_shared/exception_handlers.py
@@ -14,9 +14,9 @@ PG_ERROR_STATUS_CODE_MAP = {
 def db_exceptions(exception):
     logger.error(exception)
     db.session.rollback()
-    error_type = errorcodes.lookup(exception.orig.pgcode)
+    error_code = errorcodes.lookup(exception.orig.pgcode)
     return json.dumps(
         {
             "error": exception.orig.pgerror.strip().replace("\n", " ")
         }
-    ), PG_ERROR_STATUS_CODE_MAP.get(error_type, 500)
+    ), PG_ERROR_STATUS_CODE_MAP.get(error_code, 500)

--- a/ge_core_shared/exception_handlers.py
+++ b/ge_core_shared/exception_handlers.py
@@ -8,15 +8,35 @@ from project.app import DB as db
 logger = logging.getLogger(__name__)
 
 PG_ERROR_STATUS_CODE_MAP = {
-    "UNIQUE_VIOLATION": 409
+    # Entire postgres error class to set the status for
+    "pgclass_23": 400,
+
+    # Specific errors to set the status for
+    "UNIQUE_VIOLATION": 409,
 }
 
 def db_exceptions(exception):
     logger.error(exception)
     db.session.rollback()
     error_code = errorcodes.lookup(exception.orig.pgcode)
+
+    # Postgres errors are split into different classes, the class is obtainable
+    # from the first 2 characters in the postgres error code. This is useful if
+    # there is a need to set a status code for an entire class rather than
+    # specific errors. Classes can be found here:
+    # https://www.postgresql.org/docs/current/static/errcodes-appendix.html#ERRCODES-TABLE
+    error_class = f"pgclass_{exception.orig.pgcode[:2]}"
+
+    # Set the status code, check entire class first then see if specific error
+    # has a status code mapped.
+    http_status_code = PG_ERROR_STATUS_CODE_MAP.get(
+        error_class, 500
+    )
+    http_status_code = PG_ERROR_STATUS_CODE_MAP.get(
+        error_code, http_status_code
+    )
     return json.dumps(
         {
             "error": exception.orig.pgerror.strip().replace("\n", " ")
         }
-    ), PG_ERROR_STATUS_CODE_MAP.get(error_code, 500)
+    ), http_status_code

--- a/ge_core_shared/exception_handlers.py
+++ b/ge_core_shared/exception_handlers.py
@@ -20,7 +20,7 @@ def db_exceptions(exception):
     db.session.rollback()
     error_code = errorcodes.lookup(exception.orig.pgcode)
 
-    # Postgres errors are split into different classes, the class is obtainable
+    # Postgres errors are split into different classes, the class is obtained
     # from the first 2 characters in the postgres error code. This is useful if
     # there is a need to set a status code for an entire class rather than
     # specific errors. Classes can be found here:


### PR DESCRIPTION
Lookup psycopg2 error codes and map to http status code if needed.

Unfortunately this now locks this repo to making use of postgres drivers.

New errors will look more like this now 
```
ERROR:  duplicate key value violates unique constraint "sitedataschema_pkey" DETAIL:  Key (site_id)=(<site_id>) already exists.
```
The error types have been dropped eg:```sqlalchemy.exc.IntegrityError: (psycopg2.IntegrityError) ```