### PR TITLE
Cobusc get or create fix

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.2.0
+-----
+The `get_or_create()` function now takes an extra `defaults` argument which is used to provide values for fields that needs to be populated on
+creation, but not used for lookups.
+
 1.1.3
 -----
 Added db exception decorator to be used for flask SQLAlchemy based tests on services.

--- a/ge_core_shared/db_actions.py
+++ b/ge_core_shared/db_actions.py
@@ -206,14 +206,18 @@ def transform(
     return data
 
 
-def get_or_create(model, **kwargs):
+def get_or_create(model, defaults=None, **identifiers):
     """Django-like helper method to get or create objects.
+
+    The key-value pairs in identifiers are used for lookup purposes and
+    the key-value pairs in defaults are used when creating a model.
     """
-    instance = db.session.query(model).filter_by(**kwargs).first()
+    defaults = defaults or {}
+    instance = db.session.query(model).filter_by(**identifiers).first()
     if instance:
         return instance, False
-    else:
-        instance = model(**kwargs)
-        db.session.add(instance)
-        db.session.commit()
-        return instance, True
+
+    instance = model(**identifiers, **defaults)
+    db.session.add(instance)
+    db.session.commit()
+    return instance, True

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ LONG_DESCRIPTION_FILES = ["README.rst", "AUTHORS.rst", "CHANGELOG.rst"]
 
 setup(
     name="core-shared",
-    version="1.1.3",
+    version="1.2.0",
     description="Girl Effect Core Shared",
     long_description="".join(open(filename, "r").read() for filename in LONG_DESCRIPTION_FILES),
     author="Praekelt Consulting",


### PR DESCRIPTION
# Background
We have scripts that loads data, e.g. Access Control's `seed_data.py`. It uses `get_or_create()` to load only new data. The problem is that `get_or_create()` did not distinguish between fields that need to be used for lookups and fields that are used as default values. This lead to situations where the seed data script would fail because a lookup was performed using a unique name and a description field, no entries found because the description has been changed in the DB, an attempt made to create an entry for the unique name, which then raised a duplicate error.

# What was done
The `get_or_create()` function now takes an extra `defaults` argument which is used to provide values for fields that needs to be populated on creation, but not used for lookups.