### PR TITLE
Bugfix: Handle exceptions that does not have an `orig` attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.3.3
+-----
+- Bugfix: Handle exceptions without an `orig` attribute.
+
 1.3.2
 -----
 - Transformation omits None values.

--- a/ge_core_shared/exception_handlers.py
+++ b/ge_core_shared/exception_handlers.py
@@ -25,7 +25,8 @@ def db_exceptions(exception):
     if not hasattr(exception, "orig"):
         return json.dumps(
             {
-                "error": "{}({})".format(type(exception), str(exception).replace("\n", " "))
+                "error": "{}({})".format(type(exception).__name__,
+                                         str(exception).replace("\n", " "))
             }
         ), 500
 

--- a/ge_core_shared/exception_handlers.py
+++ b/ge_core_shared/exception_handlers.py
@@ -25,7 +25,7 @@ def db_exceptions(exception):
     if not hasattr(exception, "orig"):
         return json.dumps(
             {
-                "error": str(exception).replace("\n", " ")
+                "error": "{}({})".format(type(exception), str(exception).replace("\n", " "))
             }
         ), 500
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ LONG_DESCRIPTION_FILES = ["README.rst", "AUTHORS.rst", "CHANGELOG.rst"]
 
 setup(
     name="core-shared",
-    version="1.3.2",
+    version="1.3.3",
     description="Girl Effect Core Shared",
     long_description="".join(open(filename, "r").read() for filename in LONG_DESCRIPTION_FILES),
     author="Praekelt Consulting",


### PR DESCRIPTION
See https://praekeltorg.atlassian.net/browse/GEINFRA-428 for more information.